### PR TITLE
refactor: changes message to pt-BR and capture its exit code

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,9 +1,16 @@
-npx --no-install commitlint --edit "$1"
+#!/bin/sh
 
-if [ $? -ne 0 ]; then
-  echo "\033[0;31m🚫 Commit message rejected!\033[0m"
-  echo "Your commit message must start with one of: adds:, feat:, fix:, hotfix:, chore:, docs:, test:, style:, refactor:, ci:, perf: or build:"
-  echo "Example: feat: add user registration page"
-  echo "Please amend your commit message and try again."
+# Run commitlint and capture its exit code
+npx --no-install commitlint --edit "$1"
+COMMITLINT_EXIT_CODE=$?
+
+# If commitlint failed, show custom message
+if [ $COMMITLINT_EXIT_CODE -ne 0 ]; then
+  echo ""
+  echo "\033[0;31m🚫 Mensagem de commit rejeitada!\033[0m"
+  echo "Sua mensagem deve começar com um dos tipos: adds:, feat:, fix:, hotfix:, chore:, docs:, test:, style:, refactor:, ci:, perf: ou build:"
+  echo "Exemplo: feat: adicionar tela de login"
+  echo "Use 'git commit --amend -m \"tipo: sua mensagem\"' para corrigir."
+  echo ""
   exit 1
 fi


### PR DESCRIPTION
Alteração para capturar o erro antes de dar exit 1 e mudando para português para facilitar a leitura do erro.